### PR TITLE
MacOS launchd system for mehserve as normal user

### DIFF
--- a/meh.mehserve.plist
+++ b/meh.mehserve.plist
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.npmjs.mehserve</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>sh</string>
+        <string>-i</string>
+        <string>-c</string>
+        <string>$SHELL --login -c "/usr/local/bin/mehserve run"</string>
+    </array>
+    <key>StandardErrorPath</key>
+    <string>/dev/null</string>
+    <key>StandardOutPath</key>
+    <string>/dev/null</string>
+    <key>KeepAlive</key>
+    <true/>
+    <key>RunAtLoad</key>
+    <true/>
+</dict>
+</plist>

--- a/meh.mehserve.plist
+++ b/meh.mehserve.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
     <key>Label</key>
-    <string>com.npmjs.mehserve</string>
+    <string>meh.mehserve</string>
     <key>ProgramArguments</key>
     <array>
         <string>sh</string>

--- a/src/cli.coffee
+++ b/src/cli.coffee
@@ -19,6 +19,8 @@ if args[0] is "install"
           sudo cp #{__dirname}/meh.resolver /etc/resolver/dev
           sudo cp #{__dirname}/meh.firewall.plist /Library/LaunchDaemons/meh.firewall.plist
           sudo launchctl load -w /Library/LaunchDaemons/meh.firewall.plist
+          cp #{__dirname}/meh.mehserve.plist ~/Library/LaunchAgents/meh.mehserve.plist
+          launchctl load ~/Library/LaunchAgents/meh.mehserve.plist
         """
     when "linux"
       console.log """

--- a/src/cli.coffee
+++ b/src/cli.coffee
@@ -12,13 +12,16 @@ if args[0] is "install"
       console.log """
         We've detected you're running OS X. To get things up and running we need to set up the .meh and .dev DNS entries and a port forwarding firewall rule so mehserve takes over port 80 without requiring root privileges.
 
-        Please note that you will be responsible for undoing these changes should you wish to uninstall mehserve, and due to these changes you may get delays resolving DNS queries when mehserve is not running - we recommend running mehserve all the time using something like `pm2`.
+        Please note that you will be responsible for undoing these changes should you wish to uninstall mehserve, and due to these changes you may get delays resolving DNS queries when mehserve is not running.
 
           sudo mkdir -p /etc/resolver
           sudo cp #{__dirname}/meh.resolver /etc/resolver/meh
           sudo cp #{__dirname}/meh.resolver /etc/resolver/dev
           sudo cp #{__dirname}/meh.firewall.plist /Library/LaunchDaemons/meh.firewall.plist
           sudo launchctl load -w /Library/LaunchDaemons/meh.firewall.plist
+
+        We recommend running mehserve all the time using daemon manager. And if you follow the steps bellow you don't need to run `mehserve run` or using other daemon manager like `pm2`.
+
           cp #{__dirname}/meh.mehserve.plist ~/Library/LaunchAgents/meh.mehserve.plist
           launchctl load ~/Library/LaunchAgents/meh.mehserve.plist
         """


### PR DESCRIPTION
Except for PM2 idea for running the mehserve server in background . 
I have here the initial implementation for MacOS using launchd system as normal user.
