### PR TITLE
SSL capabilities

### DIFF
--- a/meh.firewall.plist
+++ b/meh.firewall.plist
@@ -13,7 +13,7 @@
                 <string>/bin/sh</string>
                 <string>-c</string>
                 <string>
-                  echo "rdr pass proto tcp from any to any port 80 -> 127.0.0.1 port 12439" | pfctl -a "com.apple/250.ApplicationFirewall" -f - -E
+                  (echo "rdr pass proto tcp from any to any port 80 -> 127.0.0.1 port 12439"; echo "rdr pass proto tcp from any to any port 443 -> 127.0.0.1 port 12443") | pfctl -a "com.apple/250.ApplicationFirewall" -f - -E
                 </string>
         </array>
         <key>RunAtLoad</key>

--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
   "dependencies": {
     "async": "^1.2.1",
     "express": "^4.13.0",
-    "fs-extra": "4.0.2",
     "http-proxy": "^1.11.1",
+    "mz": "2.7.0",
     "native-dns": "^0.7.0",
     "request": "^2.58.0"
   },

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "async": "^1.2.1",
     "express": "^4.13.0",
+    "fs-extra": "4.0.2",
     "http-proxy": "^1.11.1",
     "native-dns": "^0.7.0",
     "request": "^2.58.0"

--- a/package.json
+++ b/package.json
@@ -54,6 +54,8 @@
     "html/error.html",
     "index.js",
     "index.js.map",
+    "ssl.js",
+    "ssl.js.map",
     "meh.firewall.plist",
     "meh.mehserve.plist",
     "meh.resolver"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mehserve",
-  "version": "2.0.0-0",
+  "version": "2.0.0-1",
   "description": "A simple port-sharing proxy for development on multiple local domains, supports websockets",
   "main": "index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mehserve",
-  "version": "1.1.4",
+  "version": "2.0.0-0",
   "description": "A simple port-sharing proxy for development on multiple local domains, supports websockets",
   "main": "index.js",
   "bin": {

--- a/src/cli.js
+++ b/src/cli.js
@@ -1,5 +1,6 @@
 const fs = require("fs");
 const os = require("os");
+const { createSSLCertificateFor } = require("./ssl");
 
 const CONFIG_DIR = `${process.env.HOME}/.mehserve`;
 
@@ -59,10 +60,15 @@ Please note that you can change the default HTTP port 12439, and DNS port 15353 
 `);
 } else if (args[0] === "run") {
   require("./index");
-} else if (args.length === 2) {
-  const configName = args[0];
+} else if (args[0] === "ssl") {
+  createSSLCertificateFor(args[1]).then(null, e => {
+    console.error(e);
+    process.exit(1);
+  });
+} else if ((args.length === 3 && args[0] === "add") || args.length === 2) {
+  const configName = args[args.length - 2];
   const path = `${CONFIG_DIR}/${configName}`;
-  fs.writeFileSync(path, args[1]);
+  fs.writeFileSync(path, args[args.length - 1]);
 } else {
   console.log(`\
 Usage:

--- a/src/cli.js
+++ b/src/cli.js
@@ -16,7 +16,7 @@ if (args[0] === "install") {
   switch (os.platform()) {
     case "darwin":
       console.log(`\
-We've detected you're running OS X. To get things up and running we need to set up the .meh and .dev DNS entries and a port forwarding firewall rule so mehserve takes over port 80 without requiring root privileges.
+We've detected you're running OS X. To get things up and running we need to set up the .meh and .dev DNS entries and a port forwarding firewall rule so mehserve takes over ports 80 and 443 without requiring root privileges.
 
 Please note that you will be responsible for undoing these changes should you wish to uninstall mehserve, and due to these changes you may get delays resolving DNS queries when mehserve is not running.
 
@@ -36,7 +36,7 @@ We recommend running mehserve all the time using daemon manager. And if you foll
       console.log(`\
 We've detected you're running Linux. The following instructions are specifically for Ubuntu (15.10) but you should be able to adjust them to your OS.
 
-We're using dnsmasq to resolve .dev and .meh domains to localhost (127.0.0.1), and iptables to redirect port 12439 locally to port 80 so we don't need to run with root privileges.
+We're using dnsmasq to resolve .dev and .meh domains to localhost (127.0.0.1), and iptables to redirect ports 12439 and 12443 locally to ports 80 and 443 so we don't need to run with root privileges.
 
 Please note that you will be responsible for undoing these changes should you wish to uninstall mehserve. We recommend running mehserve all the time using something like \`pm2\`.
 
@@ -45,6 +45,7 @@ Please note that you will be responsible for undoing these changes should you wi
   echo -e "local=/meh/\\naddress=/meh/127.0.0.1" | sudo tee /etc/dnsmasq.d/meh-tld
   sudo service dnsmasq restart
   sudo iptables -t nat -A OUTPUT -o lo -p tcp --dport 80 -j REDIRECT --to-port 12439
+  sudo iptables -t nat -A OUTPUT -o lo -p tcp --dport 443 -j REDIRECT --to-port 12443
   sudo iptables-save\
 `);
       break;
@@ -56,7 +57,7 @@ mehserve is only tested on OS X and Ubuntu Linux, but you should be able to make
 
   console.log(`\
 
-Please note that you can change the default HTTP port 12439, and DNS port 15353 by providing PORT and DNS_PORT environment varialbes, in which case you will also need to modify resolver and firewall files accordingly.\
+Please note that you can change the default HTTP port 12439, HTTPS port 12443, and DNS port 15353 by providing PORT, SSL_PORT and DNS_PORT environment variables, in which case you will also need to modify resolver and firewall files accordingly.\
 `);
 } else if (args[0] === "run") {
   require("./index");

--- a/src/index.js
+++ b/src/index.js
@@ -4,7 +4,8 @@ const httpProxy = require("http-proxy");
 const { version } = require("./package");
 const http = require("http");
 const https = require("https");
-const fs = require("fs-extra");
+const fs = require("fs");
+const fsP = require("mz/fs");
 const tls = require("tls");
 
 const CONFIG_DIR = `${process.env.HOME}/.mehserve`;
@@ -108,7 +109,7 @@ const readConfig = (req, res, next) =>
             done(null, configName);
             return;
           }
-          const err = new Error("Configuration not found");
+          const err = new Error(`Configuration not found for host '${host}'`);
           err.code = 500;
           done(err);
         });
@@ -255,8 +256,8 @@ const MAX_SSL_CACHE_AGE_IN_MILLISECONDS = 1000 * 30;
 
 async function createSecureContext(servername) {
   const [key, cert] = await Promise.all([
-    fs.readFile(`${CONFIG_DIR}/${servername}.ssl.key`, "utf8"),
-    fs.readFile(`${CONFIG_DIR}/${servername}.ssl.crt`, "utf8"),
+    fsP.readFile(`${CONFIG_DIR}/${servername}.ssl.key`, "utf8"),
+    fsP.readFile(`${CONFIG_DIR}/${servername}.ssl.crt`, "utf8"),
   ]);
   const context = tls.createSecureContext({
     key,

--- a/src/ssl.js
+++ b/src/ssl.js
@@ -1,0 +1,100 @@
+const fs = require("mz/fs");
+const childProcess = require("mz/child_process");
+const os = require("os");
+const platform = os.platform();
+
+const CONFIG_DIR = `${process.env.HOME}/.mehserve`;
+
+function run(binary, args, options) {
+  const cp = childProcess.spawn(binary, args, options);
+  return new Promise((resolve, reject) => {
+    cp.on("close", code => {
+      if (code === 0) {
+        resolve();
+      } else {
+        reject(new Error(`${binary} exited with status '${code}'`));
+      }
+    });
+  });
+}
+
+exports.createSSLCertificateFor = async function createSSLCertificateFor(
+  hostname
+) {
+  if (!hostname || !hostname.match(/^[a-z0-9][a-z0-9-_.]+$/)) {
+    throw new Error(
+      `Unsupported hostname '${hostname}' (hints: use lower case; only alphanumeric, hyphen, underscore, dot; must start alphanumeric)`
+    );
+  }
+
+  const configSrc = `${CONFIG_DIR}/${hostname}.ssl.cnf`;
+  const keyDest = `${CONFIG_DIR}/${hostname}.ssl.key`;
+  const certDest = `${CONFIG_DIR}/${hostname}.ssl.crt`;
+  await fs.writeFile(
+    configSrc,
+    `\
+[req]
+distinguished_name = req_distinguished_name
+x509_extensions = v3_req
+prompt = no
+[req_distinguished_name]
+CN = ${hostname}
+[v3_req]
+keyUsage = keyEncipherment, dataEncipherment
+extendedKeyUsage = serverAuth
+subjectAltName = @alt_names
+[alt_names]
+DNS.1 = ${hostname}
+`
+  );
+
+  await run("openssl", [
+    "req",
+    "-new",
+    "-newkey",
+    "rsa:2048",
+    "-sha1",
+    "-days",
+    "3650",
+    "-nodes",
+    "-x509",
+    "-keyout",
+    keyDest,
+    "-out",
+    certDest,
+    "-config",
+    configSrc,
+  ]);
+  await fs.unlink(configSrc);
+  console.log("SSL certificate successfully generated");
+
+  if (platform === "darwin") {
+    console.log(`\
+
+================================================================================
+
+We'll open Keychain Access in a moment. Here are the instructions what to do:
+
+1. Click "Add"
+2. Find the certificate (e.g. "${hostname}") in the "Certificates" category,
+   select it, and click the [ｉ] button at the bottom
+3. In the popup window, click the ▶ button to the left of 'Trust', and select
+   'Always Trust' for 'When using this certificate:'.
+4. Close the popup window.
+5. When prompted, enter your password again and click Update Settings.
+6. Quit Keychain Access.
+
+Press enter to continue
+`);
+
+    await run("open", [
+      "-a",
+      "/Applications/Utilities/Keychain Access.app",
+      certDest,
+    ]);
+  } else {
+    console.log(
+      `We don't have instructions for '${platform}' yet (PRs are welcome!); you need to add '${certDest}' as a trusted certificate`
+    );
+  }
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -69,6 +69,10 @@ ansi-styles@^3.1.0:
   dependencies:
     color-convert "^1.9.0"
 
+any-promise@^1.0.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/any-promise/-/any-promise-1.3.0.tgz#abc6afeedcea52e809cdc0376aed3ce39635d17f"
+
 anymatch@^1.3.0:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/anymatch/-/anymatch-1.3.2.tgz#553dcb8f91e3c889845dfdba34c77721b90b9d7a"
@@ -990,14 +994,6 @@ fresh@0.5.2:
   version "0.5.2"
   resolved "https://registry.yarnpkg.com/fresh/-/fresh-0.5.2.tgz#3d8cadd90d976569fa835ab1f8e4b23a105605a7"
 
-fs-extra@4.0.2:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-4.0.2.tgz#f91704c53d1b461f893452b0c307d9997647ab6b"
-  dependencies:
-    graceful-fs "^4.1.2"
-    jsonfile "^4.0.0"
-    universalify "^0.1.0"
-
 fs-readdir-recursive@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs-readdir-recursive/-/fs-readdir-recursive-1.0.0.tgz#8cd1745c8b4f8a29c8caec392476921ba195f560"
@@ -1100,7 +1096,7 @@ globby@^5.0.0:
     pify "^2.0.0"
     pinkie-promise "^2.0.0"
 
-graceful-fs@^4.1.2, graceful-fs@^4.1.4, graceful-fs@^4.1.6:
+graceful-fs@^4.1.2, graceful-fs@^4.1.4:
   version "4.1.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.11.tgz#0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658"
 
@@ -1440,12 +1436,6 @@ json5@^0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/json5/-/json5-0.5.1.tgz#1eade7acc012034ad84e2396767ead9fa5495821"
 
-jsonfile@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-4.0.0.tgz#8771aae0799b64076b76640fca058f9c10e33ecb"
-  optionalDependencies:
-    graceful-fs "^4.1.6"
-
 jsonify@~0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/jsonify/-/jsonify-0.0.0.tgz#2c74b6ee41d93ca51b7b5aaee8f503631d252a73"
@@ -1570,6 +1560,14 @@ ms@2.0.0:
 mute-stream@0.0.7:
   version "0.0.7"
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.7.tgz#3075ce93bc21b8fab43e1bc4da7e8115ed1e7bab"
+
+mz@2.7.0:
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/mz/-/mz-2.7.0.tgz#95008057a56cafadc2bc63dde7f9ff6955948e32"
+  dependencies:
+    any-promise "^1.0.0"
+    object-assign "^4.0.1"
+    thenify-all "^1.0.0"
 
 nan@^2.3.0:
   version "2.7.0"
@@ -2218,6 +2216,18 @@ text-table@~0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
 
+thenify-all@^1.0.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/thenify-all/-/thenify-all-1.6.0.tgz#1a1918d402d8fc3f98fbf234db0bcc8cc10e9726"
+  dependencies:
+    thenify ">= 3.1.0 < 4"
+
+"thenify@>= 3.1.0 < 4":
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/thenify/-/thenify-3.3.0.tgz#e69e38a1babe969b0108207978b9f62b88604839"
+  dependencies:
+    any-promise "^1.0.0"
+
 through@^2.3.6:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
@@ -2280,10 +2290,6 @@ typedarray@^0.0.6:
 uid-number@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/uid-number/-/uid-number-0.0.6.tgz#0ea10e8035e8eb5b8e4449f06da1c730663baa81"
-
-universalify@^0.1.0:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.1.1.tgz#fa71badd4437af4c148841e3b3b165f9e9e590b7"
 
 unpipe@1.0.0, unpipe@~1.0.0:
   version "1.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -990,6 +990,14 @@ fresh@0.5.2:
   version "0.5.2"
   resolved "https://registry.yarnpkg.com/fresh/-/fresh-0.5.2.tgz#3d8cadd90d976569fa835ab1f8e4b23a105605a7"
 
+fs-extra@4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-4.0.2.tgz#f91704c53d1b461f893452b0c307d9997647ab6b"
+  dependencies:
+    graceful-fs "^4.1.2"
+    jsonfile "^4.0.0"
+    universalify "^0.1.0"
+
 fs-readdir-recursive@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs-readdir-recursive/-/fs-readdir-recursive-1.0.0.tgz#8cd1745c8b4f8a29c8caec392476921ba195f560"
@@ -1092,7 +1100,7 @@ globby@^5.0.0:
     pify "^2.0.0"
     pinkie-promise "^2.0.0"
 
-graceful-fs@^4.1.2, graceful-fs@^4.1.4:
+graceful-fs@^4.1.2, graceful-fs@^4.1.4, graceful-fs@^4.1.6:
   version "4.1.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.11.tgz#0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658"
 
@@ -1431,6 +1439,12 @@ json-stringify-safe@~5.0.1:
 json5@^0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/json5/-/json5-0.5.1.tgz#1eade7acc012034ad84e2396767ead9fa5495821"
+
+jsonfile@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-4.0.0.tgz#8771aae0799b64076b76640fca058f9c10e33ecb"
+  optionalDependencies:
+    graceful-fs "^4.1.6"
 
 jsonify@~0.0.0:
   version "0.0.0"
@@ -2266,6 +2280,10 @@ typedarray@^0.0.6:
 uid-number@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/uid-number/-/uid-number-0.0.6.tgz#0ea10e8035e8eb5b8e4449f06da1c730663baa81"
+
+universalify@^0.1.0:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.1.1.tgz#fa71badd4437af4c148841e3b3b165f9e9e590b7"
 
 unpipe@1.0.0, unpipe@~1.0.0:
   version "1.0.0"


### PR DESCRIPTION
- Has the server listen on HTTPS as well as HTTP.
- Sources SSL files from next to aliases when request is SSL (uses SNI to chose the right certificate)
- Adds `mehserve ssl host.name.here` command to create self-signed SSL certificates for local domains
- Caches SSL configs for 30 seconds to balance between performance and responsiveness to changes

# UPDATING

To install the latest:

```
npm install -g mehserve
```

This will continue to work as before, but if you want SSL support you'll need to redirect port 12443 to port 443 (on top of redirecting port 12439 to port 80 as you likely do already).

## Mac:

- Run `mehserve install` (just outputs instructions)
- Re-run the `sudo cp` line that references `meh.firewall.plist`
- Copy the `sudo launchctl load` command, change `load` for `unload`, then run it
- Re-run the `sudo launchctl load` command (with `load`)

## Linux:

UNTESTED

You should be able to just run:

```bash
sudo iptables -t nat -A OUTPUT -o lo -p tcp --dport 443 -j REDIRECT --to-port 12443
sudo iptables-save
```