### PR TITLE
Fix ERR_SSL_KEY_USAGE_INCOMPATIBLE error

### DIFF
--- a/src/ssl.js
+++ b/src/ssl.js
@@ -40,7 +40,7 @@ prompt = no
 [req_distinguished_name]
 CN = ${hostname}
 [v3_req]
-keyUsage = keyEncipherment, dataEncipherment
+keyUsage = nonRepudiation, digitalSignature, keyEncipherment
 extendedKeyUsage = serverAuth
 subjectAltName = @alt_names
 [alt_names]


### PR DESCRIPTION
In Chrome/Brave I was getting an `ERR_SSL_KEY_USAGE_INCOMPATIBLE` error when trying to visit `https://mysite.meh` after installing the SSL certificate generated with `mehserve ssl mysite`.

After following [this advice](https://superuser.com/a/1466427) (changing the `keyUsage` parameter for the certificate generation) and re-installing the new certificate, the error disappeared!