### PR TITLE
feat(tld): added localhost to accepted TLDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ was originally a joke... Hopefully no-one registers the `.meh` TLD!
 - Easy to configure
 - Subdomain configuration is updated on a per-request basis - no need to
   restart server
-- supports [xip.io](http://xip.io/) domains
+- supports [xip.io](http://xip.io/) and `.localhost` domains
 - SSL termination (using SNI to support multiple domains on one port)
 - Self-signed SSL certificate generation and help installing
 - `mehserve run --exponential-backoff` will automatically re-attempt requests
@@ -87,7 +87,7 @@ To set up a subdomain, simply run
 
 `mehserve add mysite 1337`
 
-This'll tell mehserve to proxy all HTTP requests for `mysite.meh`
+This'll tell mehserve to proxy all HTTP requests for `mysite.meh, mysite.localhost`,
 and `mysite.*.*.*.*.xip.io` to `localhost:1337`
 
 #### Static files 📄
@@ -97,7 +97,7 @@ Alternatively, to serve static files:
 `mehserve add staticsite /path/to/public`
 
 This'll tell mehserve to serve static content from `/path/to/public/` to anyone
-requesting `http://staticsite.meh/`
+requesting `http://staticsite.meh/`and `http://mysite.localhost`
 
 #### SSL certificates 🔐
 

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ To set up a subdomain, simply run
 
 `mehserve add mysite 1337`
 
-This'll tell mehserve to proxy all HTTP requests for `mysite.meh`, mysite.localhost`,
+This'll tell mehserve to proxy all HTTP requests for `mysite.meh`, `mysite.localhost`,
 and `mysite.*.*.*.*.xip.io` to `localhost:1337`
 
 #### Static files 📄
@@ -97,7 +97,7 @@ Alternatively, to serve static files:
 `mehserve add staticsite /path/to/public`
 
 This'll tell mehserve to serve static content from `/path/to/public/` to anyone
-requesting `http://staticsite.meh/`and `http://mysite.localhost`
+requesting `http://staticsite.meh/` or `http://mysite.localhost`
 
 #### SSL certificates 🔐
 

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ To set up a subdomain, simply run
 
 `mehserve add mysite 1337`
 
-This'll tell mehserve to proxy all HTTP requests for `mysite.meh, mysite.localhost`,
+This'll tell mehserve to proxy all HTTP requests for `mysite.meh`, mysite.localhost`,
 and `mysite.*.*.*.*.xip.io` to `localhost:1337`
 
 #### Static files 📄

--- a/src/cli.js
+++ b/src/cli.js
@@ -25,6 +25,7 @@ Please note that you will be responsible for undoing these changes should you wi
 
   sudo mkdir -p /etc/resolver
   sudo cp ${__dirname}/meh.resolver /etc/resolver/meh
+  sudo cp ${__dirname}/meh.resolver /etc/resolver/localhost
   sudo cp ${__dirname}/meh.firewall.plist /Library/LaunchDaemons/meh.firewall.plist
   sudo launchctl load -w /Library/LaunchDaemons/meh.firewall.plist
 

--- a/src/dnsserver.js
+++ b/src/dnsserver.js
@@ -3,7 +3,7 @@ const dns = require("native-dns");
 const server = dns.createServer();
 
 server.on("request", function(req, res) {
-  if (req.question[0].name.match(/\.(meh|dev)/)) {
+  if (req.question[0].name.match(/\.(meh|dev|localhost)/)) {
     res.answer.push(
       dns.A({
         name: req.question[0].name,

--- a/src/index.js
+++ b/src/index.js
@@ -13,7 +13,12 @@ const HTML_DIR = `${__dirname}/html`;
 const PORT = process.env.PORT ? process.env.PORT : 12439;
 const SSL_PORT = process.env.SSL_PORT ? process.env.SSL_PORT : 12443;
 const DNS_PORT = process.env.DNS_PORT ? process.env.DNS_PORT : 15353;
-const SUFFIXES = [/\.dev$/i, /\.meh$/i, /\.localhost$/i, /(\.[0-9]+){2,4}\.xip\.io$/i];
+const SUFFIXES = [
+  /\.dev$/i,
+  /\.meh$/i,
+  /\.localhost$/i,
+  /(\.[0-9]+){2,4}\.xip\.io$/i,
+];
 // Maximum number of attempts with exponential back-off
 let EXPONENTIAL_MAXIMUM_ATTEMPTS = 25;
 // Maximum delay between exponential back-off attempts
@@ -215,7 +220,7 @@ proxy.on("error", function(e) {
   console.error(e.stack);
 });
 
-proxy.on("proxyReq", function(proxyReq, req, res, options) {
+proxy.on("proxyReq", function(proxyReq, req, _res, _options) {
   proxyReq.setHeader(
     "x-forwarded-proto",
     req.connection.encrypted ? "https" : "http"

--- a/src/index.js
+++ b/src/index.js
@@ -13,7 +13,7 @@ const HTML_DIR = `${__dirname}/html`;
 const PORT = process.env.PORT ? process.env.PORT : 12439;
 const SSL_PORT = process.env.SSL_PORT ? process.env.SSL_PORT : 12443;
 const DNS_PORT = process.env.DNS_PORT ? process.env.DNS_PORT : 15353;
-const SUFFIXES = [/\.dev$/i, /\.meh$/i, /(\.[0-9]+){2,4}\.xip\.io$/i];
+const SUFFIXES = [/\.dev$/i, /\.meh$/i, /\.localhost$/i, /(\.[0-9]+){2,4}\.xip\.io$/i];
 // Maximum number of attempts with exponential back-off
 let EXPONENTIAL_MAXIMUM_ATTEMPTS = 25;
 // Maximum delay between exponential back-off attempts

--- a/src/ssl.js
+++ b/src/ssl.js
@@ -45,6 +45,7 @@ extendedKeyUsage = serverAuth
 subjectAltName = @alt_names
 [alt_names]
 DNS.1 = ${hostname}
+DNS.2 = ${hostname}.localhost
 DNS.2 = ${hostname}.meh
 DNS.3 = ${hostname}.dev
 `

--- a/src/ssl.js
+++ b/src/ssl.js
@@ -45,9 +45,9 @@ extendedKeyUsage = serverAuth
 subjectAltName = @alt_names
 [alt_names]
 DNS.1 = ${hostname}
-DNS.2 = ${hostname}.localhost
 DNS.2 = ${hostname}.meh
 DNS.3 = ${hostname}.dev
+DNS.4 = ${hostname}.localhost
 `
   );
 


### PR DESCRIPTION
This allows the common TLD for 127.0.0.1 to be used with mehserve as
well (see https://en.wikipedia.org/wiki/.localhost).

I'm still working on this but I wanted to propose the idea for discussion.